### PR TITLE
module file rename implementation in imports

### DIFF
--- a/src/components/BottomNavbar.tsx
+++ b/src/components/BottomNavbar.tsx
@@ -6,7 +6,7 @@ import HourglassBottomIcon from "@mui/icons-material/HourglassBottom";
 import TimerOutlinedIcon from "@mui/icons-material/TimerOutlined";
 import { useDispatch, useSelector } from "react-redux";
 import { setCurrentHomePage } from "@/redux";
-import styles from "../styles/components/BottomNavbar.module.scss";
+import styles from "@/styles/components/bottomNavbar.module.scss";
 
 type stateTypes = {
     currentHomePage: number;

--- a/src/components/InitializeStateData.tsx
+++ b/src/components/InitializeStateData.tsx
@@ -13,7 +13,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Lottie from "lottie-react";
 import loader from "@/../public/animations/loader.json";
-import styles from "@/styles/components/home/InitializeStateData.module.scss";
+import styles from "@/styles/components/home/initializeStateData.module.scss";
 
 function InitializeStateData({ setCompletedInitializationFlag }: any) {
     /* The code block is using the `useSelector` and `useDispatch` hooks from the `react-redux` library

--- a/src/components/home/alarm/AlarmRunning.tsx
+++ b/src/components/home/alarm/AlarmRunning.tsx
@@ -7,7 +7,7 @@ import { TransitionProps } from "@mui/material/transitions";
 import alarm from "@/../public/animations/alarm.json";
 import Lottie from "lottie-react";
 import { Box, Grid } from "@mui/material";
-import styles from "@/styles/components/home/alarm/AlarmRunning.module.scss";
+import styles from "@/styles/components/home/alarm/alarmRunning.module.scss";
 
 const Transition = React.forwardRef(function Transition(
     props: TransitionProps & {

--- a/src/components/home/timer/RunningTimer.tsx
+++ b/src/components/home/timer/RunningTimer.tsx
@@ -16,7 +16,7 @@ import React, {
     useState,
 } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import styles from "@/styles/components/home/timer/RunningTimer.module.scss";
+import styles from "@/styles/components/home/timer/runningTimer.module.scss";
 import AddIcon from "@mui/icons-material/Add";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
 import CircularWithValueLabel from "./miscellanceous/CircularWithValueLabel";

--- a/src/components/home/timer/TimerCompletedRingingScreen.tsx
+++ b/src/components/home/timer/TimerCompletedRingingScreen.tsx
@@ -7,7 +7,7 @@ import { TransitionProps } from "@mui/material/transitions";
 import timer from "@/../public/animations/timer.json";
 import Lottie from "lottie-react";
 import { Grid } from "@mui/material";
-import styles from "@/styles/components/home/timer/TimerCompletedRingingScreen.module.scss";
+import styles from "@/styles/components/home/timer/timerCompletedRingingScreen.module.scss";
 
 const Transition = React.forwardRef(function Transition(
     props: TransitionProps & {

--- a/src/components/miscellaneous/CustomHorizontalScrollableDialog.tsx
+++ b/src/components/miscellaneous/CustomHorizontalScrollableDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import styles from "@/styles/miscellaneous/Dialog.module.scss";
+import styles from "@/styles/miscellaneous/dialog.module.scss";
 import { useDispatch, useSelector } from "react-redux";
 import DigitalClock from "../home/clock/DigitalClock";
 import { setCurrentAnalogClockTheme } from "@/middleware/setting/clock/clockTheme/analog";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Stack } from "@mui/material";
 import BottomNavbar from "@/components/BottomNavbar";
 import TopNavbar from "@/components/TopNavbar";
-import styles from "@/styles/Home.module.scss";
+import styles from "@/styles/home.module.scss";
 import { useDispatch, useSelector } from "react-redux";
 import ClockHome from "@/components/home/clock";
 import AlarmHome from "@/components/home/alarm";


### PR DESCRIPTION
Rename AlarmRunning.module.scss to alarmRunning.module.scss Rename RunningTimer.module.scss to runningTimer.module.scss Rename InitializeStateData.module.scss to initializeStateData.module.scss Rename BottomNavbar.module.scss to bottomNavbar.module.scss Rename Home.module.scss to home.module.scss
Rename Dialog.module.scss to dialog.module.scss
Rename TimerCompletedRingingScreen.module.scss to timerCompletedRingingScreen.module.scss